### PR TITLE
Feature/its 16

### DIFF
--- a/cmd/itsb/backup.go
+++ b/cmd/itsb/backup.go
@@ -1,0 +1,19 @@
+package itsb
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "run backup from CONFIG file",
+	Long:  `Backup targets from CONFIG yaml file`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("CONFIG path is: %s", args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(backupCmd)
+}

--- a/cmd/itsb/backup.go
+++ b/cmd/itsb/backup.go
@@ -22,9 +22,9 @@ var backupCmd = &cobra.Command{
 		} else if len(args) > 1 {
 			log.Fatalln("ERROR: Undefined extra argument(s)")
 		} else {
-			var jobs Jobs
+			// var jobs Jobs
 			fmt.Printf("CONFIG path is: %s", args[0]) // will be removed
-			jobs = confparse.ParseConfig(args[0])
+			// jobs = confparse.ParseConfig(args[0])
 		}
 
 	},

--- a/cmd/itsb/backup.go
+++ b/cmd/itsb/backup.go
@@ -8,8 +8,8 @@ import (
 )
 
 var ProvidersMap = map[string]func(confparse.BackupJob){
-	// local: LocalBackup
-	// aws.rds.backup: RdsBackup
+	// "local": LocalBackup
+	// "aws.rds.backup": RdsBackup
 }
 
 var backupCmd = &cobra.Command{

--- a/cmd/itsb/backup.go
+++ b/cmd/itsb/backup.go
@@ -2,15 +2,26 @@ package itsb
 
 import (
 	"fmt"
+	"github.com/itsyndicate/itsb/pkg/confparse"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 var backupCmd = &cobra.Command{
-	Use:   "backup",
+	Use:   "backup CONFIG",
 	Short: "run backup from CONFIG file",
 	Long:  `Backup targets from CONFIG yaml file`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("CONFIG path is: %s", args[0])
+		if len(args) == 0 {
+			log.Fatalln("ERROR: CONFIG argument is missing")
+		} else if len(args) > 1 {
+			log.Fatalln("ERROR: Undefined extra argument(s)")
+		} else {
+			var jobs Jobs
+			fmt.Printf("CONFIG path is: %s", args[0]) // will be removed
+			jobs = confparse.ParseConfig(args[0])
+		}
+
 	},
 }
 

--- a/cmd/itsb/backup.go
+++ b/cmd/itsb/backup.go
@@ -7,6 +7,11 @@ import (
 	"log"
 )
 
+var ProvidersMap = map[string]func(confparse.BackupJob){
+	// local: LocalBackup
+	// aws.rds.backup: RdsBackup
+}
+
 var backupCmd = &cobra.Command{
 	Use:   "backup CONFIG",
 	Short: "run backup from CONFIG file",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -5,9 +5,22 @@ jobs:
   spec:
     rds_arn: "someArn"
     connection_string: "someConnectionString"
+  targets:
+  - type: "s3"
+    target_spec:
+      s3_bucket_name: "my-bucket"
+      s3_bucket_key: "staging/backups"
 - id: "second_backup"
   provider: local
   spec: 
     path: "somePath"
     extension: "tar"
+  targets:
+  - type: "s3"
+    target_spec:
+      s3_bucket_name: "my-bucket"
+      s3_bucket_key: "prod/backups"
+  - type: local
+    target_spec:
+      destination_dir: /etc/itsb/backup
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,13 @@
+---
+jobs:
+- id: "first_backup"
+  provider: aws.rds.backup
+  spec:
+    rds_arn: "someArn"
+    connection_string: "someConnectionString"
+- id: "second_backup"
+  provider: local
+  spec: 
+    path: "somePath"
+    extension: "tar"
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,11 @@ module github.com/itsyndicate/itsb
 go 1.21.0
 
 require (
+	github.com/spf13/cobra v1.7.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
-import "github.com/itsyndicate/itsb/cmd/itsb"
+import (
+	"github.com/itsyndicate/itsb/cmd/itsb"
+	"github.com/itsyndicate/itsb/pkg/confparse"
+)
 
 func main() {
 	itsb.Execute()
+	confparse.StructTest()
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"github.com/itsyndicate/itsb/cmd/itsb"
-	"github.com/itsyndicate/itsb/pkg/confparse"
+	// "github.com/itsyndicate/itsb/pkg/confparse"
 )
 
 func main() {
 	itsb.Execute()
-	confparse.StructTest()
+	// confparse.StructTest()
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"github.com/itsyndicate/itsb/cmd/itsb"
-	//"github.com/itsyndicate/itsb/pkg/confparse"
+	"github.com/itsyndicate/itsb/pkg/confparse"
 )
 
 func main() {
 	itsb.Execute()
-	//confparse.StructTest()
+	confparse.StructTest()
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"github.com/itsyndicate/itsb/cmd/itsb"
-	"github.com/itsyndicate/itsb/pkg/confparse"
+	//"github.com/itsyndicate/itsb/pkg/confparse"
 )
 
 func main() {
 	itsb.Execute()
-	confparse.StructTest()
+	//confparse.StructTest()
 }

--- a/pkg/confparse/confparse.go
+++ b/pkg/confparse/confparse.go
@@ -27,10 +27,26 @@ type Jobs struct {
 	Jobs []BackupJob `yaml:"jobs"`
 }
 
+func ParseConfig(configPath string) Jobs {
+	var jobs Jobs
+
+	f, err := os.ReadFile(configPath)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if err := yaml.Unmarshal(f, &jobs); err != nil {
+		log.Fatalln(err)
+	}
+
+	return jobs
+}
+
 func StructTest() {
 	f, err := os.ReadFile("examples/config.yaml")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	var jobs Jobs

--- a/pkg/confparse/confparse.go
+++ b/pkg/confparse/confparse.go
@@ -7,39 +7,6 @@ import (
 	"os"
 )
 
-type Specs struct {
-	Path             string `yaml:"path"`
-	RdsArn           string `yaml:"rds_arn"`
-	Extension        string `yaml:"extension"`
-	ConnectionString string `yaml:"connection_string"`
-	// rdsArn string
-	// connectionString string
-	// ...
-}
-
-type TargetSpecs struct {
-	S3BucketName string `yaml:"s3_bucket_name"`
-	S3BucketKey  string `yaml:"s3_bucket_key"`
-	// Local string `yaml:"local"`
-	// ...
-}
-
-type Target struct {
-	Type       string      `yaml:"type"`
-	TargetSpec TargetSpecs `yaml:"target_spec"`
-}
-
-type BackupJob struct {
-	Id       string   `yaml:"id"`
-	Provider string   `yaml:"provider"`
-	Spec     Specs    `yaml:"spec"`
-	Targets  []Target `yaml:"targets"`
-}
-
-type Jobs struct {
-	Jobs []BackupJob `yaml:"jobs"`
-}
-
 func ParseConfig(configPath string) Jobs {
 	var jobs Jobs
 

--- a/pkg/confparse/confparse.go
+++ b/pkg/confparse/confparse.go
@@ -1,0 +1,56 @@
+package confparse
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"log"
+	"os"
+)
+
+type Specs struct {
+	Path             string `yaml:"path"`
+	RdsArn           string `yaml:"rds_arn"`
+	Extension        string `yaml:"extension"`
+	ConnectionString string `yaml:"connection_string"`
+	// rdsArn string
+	// connectionString string
+	// ...
+}
+
+type BackupJob struct {
+	Id       string `yaml:"id"`
+	Provider string `yaml:"provider"`
+	Spec     Specs  `yaml:"spec"`
+}
+
+type Jobs struct {
+	Jobs []BackupJob `yaml:"jobs"`
+}
+
+func StructTest() {
+	f, err := os.ReadFile("examples/config.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var jobs Jobs
+
+	if err := yaml.Unmarshal(f, &jobs); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%+v\n", jobs)
+	fmt.Println("------------")
+	fmt.Printf("jobs[0].id: %s\n", jobs.Jobs[0].Id)
+	fmt.Printf("jobs[0].provdier: %s\n", jobs.Jobs[0].Provider)
+	fmt.Printf("jobs[0].spec.rds_arn: %s\n", jobs.Jobs[0].Spec.RdsArn)
+	fmt.Printf("jobs[0].spec.connection_string: %s\n", jobs.Jobs[0].Spec.ConnectionString)
+	fmt.Printf("jobs[0].spec.path: %s\n", jobs.Jobs[0].Spec.Path)
+	fmt.Printf("jobs[0].spec.extension: %s\n", jobs.Jobs[0].Spec.Extension)
+	fmt.Println("------------")
+	fmt.Printf("jobs[1].id: %s\n", jobs.Jobs[1].Id)
+	fmt.Printf("jobs[1].provdier: %s\n", jobs.Jobs[1].Provider)
+	fmt.Printf("jobs[1].spec.rds_arn: %s\n", jobs.Jobs[1].Spec.RdsArn)
+	fmt.Printf("jobs[1].spec.connection_string: %s\n", jobs.Jobs[1].Spec.ConnectionString)
+	fmt.Printf("jobs[1].spec.path: %s\n", jobs.Jobs[1].Spec.Path)
+	fmt.Printf("jobs[1].spec.extension: %s\n", jobs.Jobs[1].Spec.Extension)
+}

--- a/pkg/confparse/confparse.go
+++ b/pkg/confparse/confparse.go
@@ -17,10 +17,23 @@ type Specs struct {
 	// ...
 }
 
+type TargetSpecs struct {
+	S3BucketName string `yaml:"s3_bucket_name"`
+	S3BucketKey  string `yaml:"s3_bucket_key"`
+	// Local string `yaml:"local"`
+	// ...
+}
+
+type Target struct {
+	Type       string      `yaml:"type"`
+	TargetSpec TargetSpecs `yaml:"target_spec"`
+}
+
 type BackupJob struct {
-	Id       string `yaml:"id"`
-	Provider string `yaml:"provider"`
-	Spec     Specs  `yaml:"spec"`
+	Id       string   `yaml:"id"`
+	Provider string   `yaml:"provider"`
+	Spec     Specs    `yaml:"spec"`
+	Targets  []Target `yaml:"targets"`
 }
 
 type Jobs struct {
@@ -62,6 +75,9 @@ func StructTest() {
 	fmt.Printf("jobs[0].spec.connection_string: %s\n", jobs.Jobs[0].Spec.ConnectionString)
 	fmt.Printf("jobs[0].spec.path: %s\n", jobs.Jobs[0].Spec.Path)
 	fmt.Printf("jobs[0].spec.extension: %s\n", jobs.Jobs[0].Spec.Extension)
+	fmt.Printf("jobs[0].targets[0].type: %s\n", jobs.Jobs[0].Targets[0].Type)
+	fmt.Printf("jobs[0].targets[0].target_spec.s3_bucket_name: %s\n", jobs.Jobs[0].Targets[0].TargetSpec.S3BucketName)
+	fmt.Printf("jobs[0].targets[0].target_spec.s3_bucket_key: %s\n", jobs.Jobs[0].Targets[0].TargetSpec.S3BucketKey)
 	fmt.Println("------------")
 	fmt.Printf("jobs[1].id: %s\n", jobs.Jobs[1].Id)
 	fmt.Printf("jobs[1].provdier: %s\n", jobs.Jobs[1].Provider)
@@ -69,4 +85,7 @@ func StructTest() {
 	fmt.Printf("jobs[1].spec.connection_string: %s\n", jobs.Jobs[1].Spec.ConnectionString)
 	fmt.Printf("jobs[1].spec.path: %s\n", jobs.Jobs[1].Spec.Path)
 	fmt.Printf("jobs[1].spec.extension: %s\n", jobs.Jobs[1].Spec.Extension)
+	fmt.Printf("jobs[1].targets[0].type: %s\n", jobs.Jobs[1].Targets[0].Type)
+	fmt.Printf("jobs[1].targets[0].target_spec.s3_bucket_name: %s\n", jobs.Jobs[1].Targets[0].TargetSpec.S3BucketName)
+	fmt.Printf("jobs[1].targets[0].target_spec.s3_bucket_key: %s\n", jobs.Jobs[1].Targets[0].TargetSpec.S3BucketKey)
 }

--- a/pkg/confparse/types.go
+++ b/pkg/confparse/types.go
@@ -1,0 +1,34 @@
+package confparse
+
+type Specs struct {
+	Path             string `yaml:"path"`
+	RdsArn           string `yaml:"rds_arn"`
+	Extension        string `yaml:"extension"`
+	ConnectionString string `yaml:"connection_string"`
+	// rdsArn string
+	// connectionString string
+	// ...
+}
+
+type TargetSpecs struct {
+	S3BucketName string `yaml:"s3_bucket_name"`
+	S3BucketKey  string `yaml:"s3_bucket_key"`
+	// Local string `yaml:"local"`
+	// ...
+}
+
+type Target struct {
+	Type       string      `yaml:"type"`
+	TargetSpec TargetSpecs `yaml:"target_spec"`
+}
+
+type BackupJob struct {
+	Id       string   `yaml:"id"`
+	Provider string   `yaml:"provider"`
+	Spec     Specs    `yaml:"spec"`
+	Targets  []Target `yaml:"targets"`
+}
+
+type Jobs struct {
+	Jobs []BackupJob `yaml:"jobs"`
+}


### PR DESCRIPTION
I added yaml parsing along with yaml specification itself (examples dir). Also you can find a ProvidersMap map specification in cmd/itsb/backups.go. Its purpose is to map providers (which you can from yaml field) with corresponding function which implements certain backup provider (for instance backups for rds and snapshots of ec2 can be considered different providers). Each provider implementation function will take corresponding job as an argument